### PR TITLE
Add helper to download base models

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,6 +5,8 @@ This directory contains automation scripts for the fine-tuning pipeline.
   model using the `quantize-rs` CLI, and packages the result into GGUF format via
   `gguf-writer`.
 * `run_pipeline.sh` - Convenience wrapper that invokes `run_pipeline.py`.
+* `download_base_model.py` - Interactive helper to download a base model from
+  Hugging Face into the `base_model/` directory.
 
 Run `./run_pipeline.sh` from this directory (or via `scripts/run_pipeline.sh`)
 with optional arguments such as `--epochs` or `--quant-format` to execute the

--- a/scripts/download_base_model.py
+++ b/scripts/download_base_model.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Interactive script to download base models from Hugging Face."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+try:
+    from huggingface_hub import snapshot_download
+except ImportError:
+    print("huggingface_hub is required. Install via `pip install huggingface_hub`.", file=sys.stderr)
+    sys.exit(1)
+
+WORKSPACE = Path(__file__).resolve().parents[1]
+BASE_DIR = WORKSPACE / "base_model"
+
+MODELS = {
+    "Meta Llama 3 8B": "meta-llama/Meta-Llama-3-8B",
+    "Gemma 7B": "google/gemma-7b",
+    "Phi-2": "microsoft/phi-2",
+    "Llama 2 7B": "meta-llama/Llama-2-7b-hf",
+    "Mistral 7B": "mistralai/Mistral-7B-v0.1",
+    "Mistral 7B Instruct": "mistralai/Mistral-7B-Instruct-v0.2",
+    "Qwen1.5 7B": "Qwen/Qwen1.5-7B",
+    "Zephyr 7B Beta": "huggingfaceh4/zephyr-7b-beta",
+    "Flan-T5 Base": "google/flan-t5-base",
+    "Gemma 2B": "google/gemma-2b",
+    "StableLM Zephyr 3B": "stabilityai/stablelm-zephyr-3b",
+    "Falcon 7B": "tiiuae/falcon-7b",
+    "OPT 1.3B": "facebook/opt-1.3b",
+}
+
+
+def choose_model() -> str:
+    print("Available models:\n")
+    items = list(MODELS.items())
+    for idx, (name, repo) in enumerate(items, start=1):
+        print(f"{idx}. {name} ({repo})")
+    print()
+    while True:
+        choice = input(f"Select a model [1-{len(items)}]: ")
+        if not choice.isdigit():
+            print("Please enter a number.")
+            continue
+        idx = int(choice)
+        if 1 <= idx <= len(items):
+            return items[idx - 1][1]
+        print("Invalid selection. Try again.")
+
+
+def download_model(repo_id: str) -> None:
+    dest = BASE_DIR / repo_id.replace("/", "_")
+    dest.mkdir(parents=True, exist_ok=True)
+    print(f"Downloading {repo_id} to {dest} ...")
+    snapshot_download(repo_id, local_dir=dest, local_dir_use_symlinks=False)
+    print("Download complete.")
+
+
+def main() -> None:
+    BASE_DIR.mkdir(exist_ok=True)
+    repo_id = choose_model()
+    download_model(repo_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `download_base_model.py` interactive script to fetch common models from Hugging Face
- document the new helper in scripts README

## Testing
- `python3 -m py_compile scripts/download_base_model.py scripts/run_pipeline.py`
- `python3 scripts/download_base_model.py <<EOF
1
EOF` *(fails: huggingface_hub missing)*

------
https://chatgpt.com/codex/tasks/task_e_686d550952e4832382277f5d87eb4d68