### PR TITLE
Update pipeline to use base_models subdirs

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -19,7 +19,7 @@ Organizing your workspace by stages will make the process more manageable. A rec
 
 ```text
 fine-tune-workspace/
-├── base_model/              # Original base model files (from HF or elsewhere)
+├── base_models/             # Original base model files (from HF or elsewhere)
 │   ├── config.json          # Model architecture configuration
 │   ├── tokenizer.json       # Tokenizer (or vocab files, merges, etc.)
 │   └── model.safetensors    # (Optional) base model weights in safetensors (FP16/FP32)
@@ -55,7 +55,7 @@ fine-tune-workspace/
 **Training Output:** After fine-tuning, you will have one of two outcomes:
 
 - If you performed a standard fine-tune (full model update, no LoRA), the output directory (e.g. `finetune_output/`) will contain a new model checkpoint (commonly `pytorch_model.bin` or `.safetensors`) with the fully fine-tuned weights.
-- If you used LoRA/QLoRA, the output directory will contain the small LoRA adapter weights (e.g. `adapter_model.bin/safetensors`) and possibly a final merged checkpoint if you explicitly merged during training. The base model weights are typically not saved again (since they were loaded from `base_model/`).
+- If you used LoRA/QLoRA, the output directory will contain the small LoRA adapter weights (e.g. `adapter_model.bin/safetensors`) and possibly a final merged checkpoint if you explicitly merged during training. The base model weights are typically not saved again (since they were loaded from `base_models/`).
 
 **Merging LoRA Weights:** In a LoRA scenario, the next step is to merge the learned LoRA deltas into the base model to produce a full set of fine-tuned weights. This can be done using the PEFT library’s utilities. For example, after training you can load the base model and apply `PeftModel.from_pretrained(...)` to load the LoRA, then call `model.merge_and_unload()` to merge the adapter into the model’s weights. This gives you a **merged model** in memory which represents the fully fine-tuned model in full precision. Save this merged model for the export stage.
 

--- a/scripts/download_base_model.py
+++ b/scripts/download_base_model.py
@@ -14,7 +14,7 @@ except ImportError:
     sys.exit(1)
 
 WORKSPACE = Path(__file__).resolve().parents[1]
-BASE_DIR = WORKSPACE / "base_model"
+BASE_DIR = WORKSPACE / "base_models"
 
 MODELS = {
     "Meta Llama 3 8B": "meta-llama/Meta-Llama-3.1-8B",
@@ -51,7 +51,7 @@ def choose_model() -> str:
 
 
 def download_model(repo_id: str) -> None:
-    dest = BASE_DIR / repo_id.replace("/", "_")
+    dest = BASE_DIR / repo_id.split("/")[-1]
     dest.mkdir(parents=True, exist_ok=True)
     print(f"Downloading {repo_id} to {dest} ...")
     snapshot_download(repo_id, local_dir=dest, local_dir_use_symlinks=False)

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -37,7 +37,7 @@ except Exception:
     pass
 
 WORKSPACE = Path(__file__).resolve().parents[1]
-BASE_MODEL_DIR = WORKSPACE / "base_model"
+BASE_MODELS_DIR = WORKSPACE / "base_models"
 DATA_DIR = WORKSPACE / "data"
 FINETUNE_OUTPUT_DIR = WORKSPACE / "finetune_output"
 EXPORTED_DIR = WORKSPACE / "exported_model"
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 # --------------------------- Stage 1 ---------------------------------------
 
-def run_finetuning(base_model: Path = BASE_MODEL_DIR,
+def run_finetuning(base_model: Path,
                    data_dir: Path = DATA_DIR,
                    output_dir: Path = FINETUNE_OUTPUT_DIR,
                    num_train_epochs: int = 1) -> None:
@@ -178,13 +178,17 @@ def main() -> None:
     parser.add_argument("--epochs", type=int, default=1, help="Number of training epochs")
     parser.add_argument("--quant-format", default="Q4_0", help="Quantization format")
     parser.add_argument("--model-name", default="finetuned-model", help="Name for GGUF package")
+    parser.add_argument("--base-model", required=True,
+                        help="Directory name of the base model inside base_models/")
     args = parser.parse_args()
 
     logger.info(f"{Fore.CYAN}Starting fine-tuning pipeline{Style.RESET_ALL}")
 
+    base_model_dir = BASE_MODELS_DIR / args.base_model
+
     with tqdm(total=4, bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}]") as pbar:
         pbar.set_description("Finetuning")
-        run_finetuning(num_train_epochs=args.epochs)
+        run_finetuning(base_model=base_model_dir, num_train_epochs=args.epochs)
         pbar.update(1)
 
         pbar.set_description("Exporting")


### PR DESCRIPTION
## Summary
- update `download_base_model.py` to store models under `base_models/<model>`
- update `run_pipeline.py` to accept `--base-model` argument
- adjust guide to document `base_models` directory

## Testing
- `python3 -m py_compile scripts/*.py`


------
https://chatgpt.com/codex/tasks/task_e_686d6dca42b083238a02fae8f5d73572